### PR TITLE
Add an explicit config for building readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+# Config for building https://try.readthedocs.io/
+version: 2
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3"


### PR DESCRIPTION
The explicit configuration is now required:
https://blog.readthedocs.com/migrate-configuration-v2/